### PR TITLE
Initial item class creation wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@craco/craco": "^7.0.0-alpha.7",
     "@metaplex-foundation/mpl-token-metadata": "^2.2.2",
     "@project-serum/anchor": "^0.25.0",
-    "@raindrops-protocol/raindrops": "^0.0.6",
+    "@raindrops-protocol/raindrops": "^0.0.7",
     "@solana-mobile/wallet-adapter-mobile": "^0.0.1-alpha.5",
     "@solana/spl-token": "^0.2.0",
     "@solana/wallet-adapter-base": "^0.9.9",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,36 +1,29 @@
-import React, { FC, Key, ReactNode, useEffect, useMemo, useState } from "react";
-
-import {
-  SolanaMobileWalletAdapter,
-  createDefaultAuthorizationResultCache,
-} from "@solana-mobile/wallet-adapter-mobile";
-import {
-  ConnectionProvider,
-  WalletProvider,
-} from "@solana/wallet-adapter-react";
-import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
-import {
-  GlowWalletAdapter,
-  PhantomWalletAdapter,
-  SlopeWalletAdapter,
-  SolflareWalletAdapter,
-  TorusWalletAdapter,
-} from "@solana/wallet-adapter-wallets";
+import { FC, ReactNode, useState } from "react";
 import { BaseProvider, DarkTheme } from "baseui";
 import { Client as Styletron } from "styletron-engine-atomic";
 import { Provider as StyletronProvider } from "styletron-react";
-import useNetwork, {
-  getNetworkForWalletAdapter,
+import {
   NetworkProvider,
   Networks,
 } from "./hooks/useNetwork";
+import { CreateItemClassWizard } from "./createItemClass";
+import { Header } from "./components/Header";
+import { Block } from "baseui/block";
+import ConnectedWallet from "./components/ConnectedWallet";
 
 export const App: FC = () => {
   return (
     <StyletronProvider value={engine}>
       <BaseProvider theme={DarkTheme}>
         <Context>
-          <Content />
+          <Block
+            display="flex"
+            flexDirection="column"
+            $style={{ minWidth: "100vw", minHeight: "100vh" }}
+          >
+            <Header />
+            <CreateItemClassWizard />
+          </Block>
         </Context>
       </BaseProvider>
     </StyletronProvider>
@@ -51,38 +44,4 @@ const Context: FC<{ children: ReactNode }> = ({ children }) => {
       <ConnectedWallet>{children}</ConnectedWallet>
     </NetworkProvider>
   );
-};
-
-const ConnectedWallet = ({ children }: { children: ReactNode }) => {
-  const { endpoint, network } = useNetwork();
-  const walletAdapterNetwork = getNetworkForWalletAdapter(network);
-
-  // @solana/wallet-adapter-wallets includes all the adapters but supports tree shaking and lazy loading --
-  // Only the wallets you configure here will be compiled into your application, and only the dependencies
-  // of wallets that your users connect to will be loaded.
-  const wallets = useMemo(
-    () => [
-      new SolanaMobileWalletAdapter({
-        appIdentity: { name: "Raindrops Creator" },
-        authorizationResultCache: createDefaultAuthorizationResultCache(),
-      }),
-      new PhantomWalletAdapter(),
-      new GlowWalletAdapter(),
-      new SlopeWalletAdapter(),
-      new SolflareWalletAdapter({ network: walletAdapterNetwork }),
-      new TorusWalletAdapter(),
-    ],
-    [network]
-  );
-  return (
-    <ConnectionProvider endpoint={endpoint}>
-      <WalletProvider wallets={wallets} autoConnect>
-        <WalletModalProvider>{children}</WalletModalProvider>
-      </WalletProvider>
-    </ConnectionProvider>
-  );
-};
-
-const Content: FC = () => {
-  return null;
 };

--- a/src/components/TokenDisplay/index.tsx
+++ b/src/components/TokenDisplay/index.tsx
@@ -18,7 +18,11 @@ const TokenDisplay = ({
   qty,
   selected,
   handleToggleSelect,
-}: TokenInfo & Omit<LoadedTokenProps, "imageSrc" | "tokenName">) => {
+  setMetadata: setMetadataValue,
+}: TokenInfo &
+  Omit<LoadedTokenProps, "imageSrc" | "tokenName"> & {
+    setMetadata: (arg: Metadata | undefined) => void;
+  }) => {
   const { connection } = useConnection();
   const [metadata, setMetadata] = React.useState<Metadata>();
   const [loadingMetadata, setLoadingMetadata] = React.useState(true);
@@ -30,6 +34,11 @@ const TokenDisplay = ({
       setLoadingMetadata(false);
     });
   }, [connection, mintAddr]);
+  useEffect(() => {
+    if (selected && !loadingMetadata) {
+      setMetadataValue(metadata);
+    }
+  }, [selected, loadingMetadata]);
   const [imageSrc, setImageSrc] = React.useState<string>();
   const [, setLoadingImage] = React.useState(true);
   useEffect(() => {
@@ -42,13 +51,16 @@ const TokenDisplay = ({
       });
     }
   }, [metadata]);
+  const toggleSelect = handleToggleSelect
+    ? () => handleToggleSelect()
+    : undefined;
   return (
     <>
       {metadata ? (
         <LoadedToken
           imageSrc={imageSrc}
           tokenName={metadata.data.name}
-          handleToggleSelect={handleToggleSelect}
+          handleToggleSelect={toggleSelect}
           qty={qty}
           selected={selected}
         />

--- a/src/components/Wizard/BooleanFormStep.tsx
+++ b/src/components/Wizard/BooleanFormStep.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { SubStepProps } from "./FormStep";
+import { FormBlock, SubmitButton } from "./Form";
+import { RadioInput } from "./Inputs";
+import {
+  getBooleanFromString,
+  getStringFromBoolean,
+} from "./Inputs/Radio";
+
+const BooleanFormStep = ({ handleSubmit, title, help, initialValue }: BooleanFormStepProps) => {
+  const [submitDisabled, setSubmitDisabled] = useState<boolean>(
+    initialValue === undefined
+  );
+  const handleSelect = (value: string) => {
+    handleSubmit(getBooleanFromString(value));
+  };
+  const handleDeselect = () => setSubmitDisabled(true);
+  return (
+    <FormBlock>
+      <RadioInput.Standalone
+        title={title}
+        options={[
+          { title: "Yes", value: "true" },
+          { title: "No", value: "false" },
+        ]}
+        onSelect={handleSelect}
+        onDeselect={handleDeselect}
+        help={help}
+        value={getStringFromBoolean(initialValue)}
+      />
+      <SubmitButton
+        type="button"
+        onClick={() => handleSubmit(initialValue)}
+        disabled={submitDisabled}
+      >
+        Next
+      </SubmitButton>
+    </FormBlock>
+  );
+};
+
+interface BooleanFormStepProps extends Omit<SubStepProps, 'data'> {
+  title: string;
+  help?: string;
+  initialValue?: boolean | undefined;
+}
+
+export {BooleanFormStep}

--- a/src/components/Wizard/Form.tsx
+++ b/src/components/Wizard/Form.tsx
@@ -1,6 +1,6 @@
 import React, { FormEventHandler } from "react";
 import { Block } from "baseui/block";
-import { Button } from "baseui/button";
+import { Button, ButtonProps } from "baseui/button";
 import { useFormikContext } from "formik";
 
 export function Form({
@@ -12,35 +12,44 @@ export function Form({
 }) {
   return (
     <form onSubmit={onSubmit}>
-      <Block
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-        padding="scale800"
-      >
-        {children}
-      </Block>
+      <FormBlock>{children}</FormBlock>
     </form>
   );
 }
+
+export const FormBlock = ({ children }: { children: React.ReactNode }) => (
+  <Block
+    display="flex"
+    flexDirection="column"
+    alignItems="center"
+    padding="scale800"
+  >
+    {children}
+  </Block>
+);
 
 type SubmitButtonProps = {
   isLoading: boolean;
   disabled: boolean;
   children: React.ReactNode;
+  type?: ButtonProps['type'];
+  onClick?: ButtonProps['onClick'];
 };
 
 export function SubmitButton({
   isLoading,
   disabled,
   children,
+  onClick,
+  type = "submit"
 }: SubmitButtonProps) {
   return (
     <Button
-      type="submit"
+      type={type}
       disabled={disabled}
       isLoading={isLoading}
       $style={{ margin: "20px" }}
+      onClick={onClick}
     >
       {children}
     </Button>

--- a/src/components/Wizard/Form.tsx
+++ b/src/components/Wizard/Form.tsx
@@ -29,8 +29,8 @@ export const FormBlock = ({ children }: { children: React.ReactNode }) => (
 );
 
 type SubmitButtonProps = {
-  isLoading: boolean;
-  disabled: boolean;
+  isLoading?: boolean;
+  disabled?: boolean;
   children: React.ReactNode;
   type?: ButtonProps['type'];
   onClick?: ButtonProps['onClick'];

--- a/src/components/Wizard/FormStep.tsx
+++ b/src/components/Wizard/FormStep.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Block } from "baseui/block";
 import { Button, KIND } from "baseui/button";
 import { ArrowLeft } from "baseui/icon";
@@ -19,9 +19,13 @@ export function StepLayout<ComponentProps = {}>({
   setValues,
   ...componentProps
 }: StepLayoutProps<ComponentProps>) {
+  const [submitting, setSubmitting] = useState<boolean>(false);
   const onSubmit = (arg: any) => {
-    setValues({ ...values, ...arg });
-    next();
+    if (!submitting) { // Ensure each step can only submit ONCE
+      setSubmitting(true)
+      setValues({ ...values, ...arg });
+      next();
+    }
   };
   return (
     <Block

--- a/src/components/Wizard/Inputs/ItemClassKey.tsx
+++ b/src/components/Wizard/Inputs/ItemClassKey.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from "react";
-import { FormikErrors, useFormikContext } from "formik";
+import { useFormikContext } from "formik";
+import { State } from "@raindrops-protocol/raindrops";
+
 import { FormControlBlock } from "./FormControlBlock";
 import { InputProps } from "./common";
 import * as PublicKeyInput from "./PublicKey";
@@ -17,13 +19,18 @@ export function Inline({
   onBlur,
   setValue,
   setError,
+  setItemClass,
 }: ItemClassKeyInputProps) {
-  const { loading, itemClass, failed } = useItemClass(!error ? value : undefined);
+  const { loading, itemClass, failed } = useItemClass(value);
   useEffect(() => {
-    if (value && failed) {
-      setError("Item class could not be found - please re-check the key");
+    if (value && !loading) {
+      if (failed) {
+        setError("Item class could not be found - please re-check the key");
+      } else if (itemClass) {
+        setItemClass(itemClass)
+      }
     }
-  }, [value, failed]);
+  }, [value, failed, itemClass, loading]);
   return (
     <FormControlBlock title={title} help={help} error={error}>
       <>
@@ -37,7 +44,7 @@ export function Inline({
         {!error && value && loading && (
           <LoadingMessage message={`Looking up item class ${value}...`} />
         )}
-        {!error && value && !loading && itemClass && (
+        {!failed && value && !loading && itemClass && (
           <JSONInput.Display name="itemclass" value={itemClass} />
         )}
       </>
@@ -45,19 +52,36 @@ export function Inline({
   );
 }
 
-export function Formik(props: Omit<ItemClassKeyInputProps, "setValue" | "setError">) {
-  const { setFieldValue, setFieldError } = useFormikContext();
+export function Formik(
+  props: Omit<ItemClassKeyInputProps, "setValue" | "setError" | "setItemClass">
+) {
+  const { setFieldValue, setFieldError, errors } = useFormikContext();
   const setValue = (value: string) => {
     setFieldValue(props.name, value);
-  }
+  };
   const setError = (error: string) => {
     setFieldError(props.name, error);
-  }
-  return <Inline {...props} setValue={setValue} setError={setError} />;
+  };
+  const ITEMCLASS_FIELD = `${props.name}_itemclass`
+  const setItemClass = (value: State.Item.ItemClass) => {
+    setFieldValue(ITEMCLASS_FIELD, value);
+  };
+  // @ts-ignore
+  const itemClassError : string = Object.values(errors?.[ITEMCLASS_FIELD] || {})?.[0]
+  return (
+    <Inline
+      {...props}
+      error={props.error || itemClassError}
+      setValue={setValue}
+      setError={setError}
+      setItemClass={setItemClass}
+    />
+  );
 }
 
 export interface ItemClassKeyInputProps extends InputProps {
   value: string;
   setValue: (arg: string) => void;
   setError: (arg: string) => void;
+  setItemClass: (arg: State.Item.ItemClass) => void;
 }

--- a/src/components/Wizard/Inputs/ItemClassKey.tsx
+++ b/src/components/Wizard/Inputs/ItemClassKey.tsx
@@ -1,0 +1,63 @@
+import { useEffect } from "react";
+import { FormikErrors, useFormikContext } from "formik";
+import { FormControlBlock } from "./FormControlBlock";
+import { InputProps } from "./common";
+import * as PublicKeyInput from "./PublicKey";
+import useItemClass from "../../../hooks/useItemClass";
+import { LoadingMessage } from "../../LoadingMessage";
+import * as JSONInput from "./JSON";
+
+export function Inline({
+  title,
+  help,
+  value,
+  name,
+  error,
+  onChange,
+  onBlur,
+  setValue,
+  setError,
+}: ItemClassKeyInputProps) {
+  const { loading, itemClass, failed } = useItemClass(!error ? value : undefined);
+  useEffect(() => {
+    if (value && failed) {
+      setError("Item class could not be found - please re-check the key");
+    }
+  }, [value, failed]);
+  return (
+    <FormControlBlock title={title} help={help} error={error}>
+      <>
+        <PublicKeyInput.Inline
+          name={name}
+          setValue={setValue}
+          onChange={onChange}
+          onBlur={onBlur}
+          value={value}
+        />
+        {!error && value && loading && (
+          <LoadingMessage message={`Looking up item class ${value}...`} />
+        )}
+        {!error && value && !loading && itemClass && (
+          <JSONInput.Display name="itemclass" value={itemClass} />
+        )}
+      </>
+    </FormControlBlock>
+  );
+}
+
+export function Formik(props: Omit<ItemClassKeyInputProps, "setValue" | "setError">) {
+  const { setFieldValue, setFieldError } = useFormikContext();
+  const setValue = (value: string) => {
+    setFieldValue(props.name, value);
+  }
+  const setError = (error: string) => {
+    setFieldError(props.name, error);
+  }
+  return <Inline {...props} setValue={setValue} setError={setError} />;
+}
+
+export interface ItemClassKeyInputProps extends InputProps {
+  value: string;
+  setValue: (arg: string) => void;
+  setError: (arg: string) => void;
+}

--- a/src/components/Wizard/Inputs/Radio.tsx
+++ b/src/components/Wizard/Inputs/Radio.tsx
@@ -83,6 +83,15 @@ function Inner({
         onClick={(_event, index) => {
           setSelected(index === selected ? -1 : index);
         }}
+        overrides={{
+          Root: {
+            style: {
+              width: "fit-content",
+              marginLeft: "auto",
+              marginRight: "auto",
+            },
+          },
+        }}
       >
         {options.map(({ title, value }) => {
           return (
@@ -95,6 +104,28 @@ function Inner({
     </FormControlBlock>
   );
 }
+
+export const getBooleanFromString = (strVal: string) => {
+  switch (strVal) {
+    case "true":
+      return true;
+    case "false":
+      return false;
+    default:
+      return undefined;
+  }
+};
+
+export const getStringFromBoolean = (boolVal: boolean) => {
+  switch (boolVal) {
+    case true:
+      return "true";
+    case false:
+      return "false";
+    default:
+      return "";
+  }
+};
 
 export type RadioOption = {
   title: React.ReactNode;

--- a/src/components/Wizard/Inputs/Radio.tsx
+++ b/src/components/Wizard/Inputs/Radio.tsx
@@ -116,7 +116,7 @@ export const getBooleanFromString = (strVal: string) => {
   }
 };
 
-export const getStringFromBoolean = (boolVal: boolean) => {
+export const getStringFromBoolean = (boolVal: boolean | undefined) => {
   switch (boolVal) {
     case true:
       return "true";

--- a/src/components/Wizard/Inputs/Radio.tsx
+++ b/src/components/Wizard/Inputs/Radio.tsx
@@ -33,25 +33,35 @@ export function Inline({
 export function Standalone({
   options,
   onSelect,
+  onDeselect,
   value,
   ...innerProps
 }: RadioInputStandaloneProps) {
+  const [touched, setTouched] = React.useState<boolean>(false)
   const [selected, setSelected] = React.useState<number>(
     options.findIndex(({ value: optionValue }) => optionValue === value)
-  );
+    );
   const selectedValue: typeof value =
     selected === -1 ? undefined : options[selected].value;
+  const handleSelect = (value: number) => {
+    setTouched(true);
+    setSelected(value);
+  }
 
   React.useEffect(() => {
-    if (selected !== -1 && selectedValue !== value) {
-      onSelect(selectedValue);
+    if (touched) {
+      if (selected !== -1) {
+        onSelect(selectedValue);
+      } else if (onDeselect) {
+        onDeselect();
+      }
     }
   }, [selectedValue, value]);
   return (
     <Inner
       options={options}
       selected={selected}
-      setSelected={setSelected}
+      setSelected={handleSelect}
       {...innerProps}
     />
   );
@@ -100,6 +110,7 @@ interface RadioInputProps extends InputProps {
 interface RadioInputStandaloneProps
   extends Omit<InnerProps, "selected" | "setSelected"> {
   onSelect: (arg: any) => void;
+  onDeselect?: () => void;
   value: any;
 }
 

--- a/src/components/Wizard/Inputs/Token.tsx
+++ b/src/components/Wizard/Inputs/Token.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from "@metaplex-foundation/mpl-token-metadata";
 import { useFormikContext } from "formik";
 import { FlexGrid, FlexGridItem } from "baseui/flex-grid";
 import { Block } from "baseui/block";
@@ -15,21 +16,25 @@ export function Inline({
   value,
   error,
   setValue,
+  setMetadataValue,
 }: TokenInputProps) {
   const { loading, tokens } = useFetchWalletTokens();
-  const tokenDisplays = useMemo(() =>
-    tokens.map(({ mintAddr, qty }) => (
-      <FlexGridItem key={`token_${mintAddr}`}>
-        <TokenDisplay
-          mintAddr={mintAddr}
-          selected={mintAddr === value}
-          qty={qty}
-          handleToggleSelect={() =>
-            setValue(value === mintAddr ? undefined : mintAddr)
-          }
-        />
-      </FlexGridItem>
-    )), [tokens, value]
+  const tokenDisplays = useMemo(
+    () =>
+      tokens.map(({ mintAddr, qty }) => (
+        <FlexGridItem key={`token_${mintAddr}`}>
+          <TokenDisplay
+            mintAddr={mintAddr}
+            selected={mintAddr === value}
+            qty={qty}
+            handleToggleSelect={() => {
+              setValue(value === mintAddr ? undefined : mintAddr);
+            }}
+            setMetadata={setMetadataValue}
+          />
+        </FlexGridItem>
+      )),
+    [tokens, value]
   );
   return (
     <FormControlBlock title={title} help={help} error={error}>
@@ -50,15 +55,26 @@ export function Inline({
   );
 }
 
-export function Formik(props: Omit<TokenInputProps, "setValue">) {
+export function Formik(
+  props: Omit<TokenInputProps, "setValue" | "setMetadataValue">
+) {
   const { setFieldValue } = useFormikContext();
   const setValue = (value: string | undefined) =>
     setFieldValue(props.name, value);
-  return <Inline {...props} setValue={setValue} />;
+  const setMetadataValue = (value: Metadata | undefined) =>
+    setFieldValue(`${props.name}_metadata`, value);
+  return (
+    <Inline
+      {...props}
+      setValue={setValue}
+      setMetadataValue={setMetadataValue}
+    />
+  );
 }
 
 export interface TokenInputProps
   extends Omit<InputProps, "onChange" | "onBlur"> {
   value: string | undefined;
   setValue: (arg: string | undefined) => void;
+  setMetadataValue: (arg: Metadata | undefined) => void;
 }

--- a/src/components/Wizard/Inputs/TokenMint.tsx
+++ b/src/components/Wizard/Inputs/TokenMint.tsx
@@ -1,0 +1,65 @@
+import { useFormikContext } from "formik";
+
+import { FormControlBlock } from "./FormControlBlock";
+import { InputProps } from "./common";
+import * as PublicKeyInput from "./PublicKey";
+import TokenDisplay from "../../TokenDisplay";
+import { Metadata } from "@metaplex-foundation/mpl-token-metadata";
+
+export function Inline({
+  title,
+  help,
+  value,
+  name,
+  error,
+  onChange,
+  onBlur,
+  setValue,
+  setMetadataValue,
+}: TokenMintInputProps) {
+  return (
+    <FormControlBlock title={title} help={help} error={error}>
+      <>
+        <PublicKeyInput.Inline
+          name={name}
+          setValue={setValue}
+          onChange={onChange}
+          onBlur={onBlur}
+          value={value}
+        />
+        {!error && value && (
+          <TokenDisplay mintAddr={value} setMetadata={setMetadataValue} />
+        )}
+      </>
+    </FormControlBlock>
+  );
+}
+
+export function Formik(
+  props: Omit<TokenMintInputProps, "setValue" | "setError" | "setMetadataValue">
+) {
+  const { setFieldValue, setFieldError } = useFormikContext();
+  const setValue = (value: string) => {
+    setFieldValue(props.name, value);
+  };
+  const setError = (error: string) => {
+    setFieldError(props.name, error);
+  };
+  const setMetadataValue = (value: Metadata | undefined) =>
+    setFieldValue(`${props.name}_metadata`, value);
+  return (
+    <Inline
+      {...props}
+      setValue={setValue}
+      setError={setError}
+      setMetadataValue={setMetadataValue}
+    />
+  );
+}
+
+export interface TokenMintInputProps extends InputProps {
+  value: string;
+  setValue: (arg: string) => void;
+  setError: (arg: string) => void;
+  setMetadataValue: (arg: Metadata | undefined) => void;
+}

--- a/src/components/Wizard/Inputs/index.ts
+++ b/src/components/Wizard/Inputs/index.ts
@@ -8,3 +8,4 @@ export * as PermissivenessInput from "./Permissiveness"
 export * as StringInput from "./String";
 export * as JSONInput from "./JSON";
 export * as ItemClassKeyInput from "./ItemClassKey";
+export * as TokenMintInput from "./TokenMint";

--- a/src/components/Wizard/Inputs/index.ts
+++ b/src/components/Wizard/Inputs/index.ts
@@ -7,3 +7,4 @@ export * as DurationInput from "./Duration";
 export * as PermissivenessInput from "./Permissiveness"
 export * as StringInput from "./String";
 export * as JSONInput from "./JSON";
+export * as ItemClassKeyInput from "./ItemClassKey";

--- a/src/components/Wizard/index.tsx
+++ b/src/components/Wizard/index.tsx
@@ -135,7 +135,7 @@ function Wizard<ComponentProps = {}>({
 
 type WizardProps = {
   children: React.ReactNode;
-  onComplete: () => void;
+  onComplete?: () => void;
   values: any;
   setValues: (arg: any) => void;
   restartOnChange?: any;

--- a/src/components/Wizard/index.tsx
+++ b/src/components/Wizard/index.tsx
@@ -14,6 +14,7 @@ function Wizard<ComponentProps = {}>({
   onComplete,
   values,
   setValues,
+  restartOnChange,
 }: WizardProps) {
   const { isMobile } = useDevice();
   const [steps, setSteps] = React.useState<StepProps<ComponentProps>[]>([]);
@@ -55,6 +56,10 @@ function Wizard<ComponentProps = {}>({
           : newSteps[0])
     );
   }, [children, currentStepIndex]);
+
+  React.useEffect(() => {
+    goToStep(0)
+  }, [restartOnChange])
 
   if (!currentStep) return null;
   const { onPrevious, onNext } = currentStep;
@@ -133,6 +138,7 @@ type WizardProps = {
   onComplete: () => void;
   values: any;
   setValues: (arg: any) => void;
+  restartOnChange?: any;
 };
 
 Wizard.Step = FormStep;

--- a/src/components/Wizard/useFormWizard.ts
+++ b/src/components/Wizard/useFormWizard.ts
@@ -5,13 +5,13 @@ export const useFormWizard = ({
   complete,
 }: {
   steps: string[];
-  complete: () => void;
+  complete?: () => void;
 }) => {
   const [history, setHistory] = useState<string[]>([]);
   const [currentStep, setCurrentStep] = useState<number>(0);
   useEffect(() => {
-    if (currentStep && currentStep == steps.length) {
-      complete();
+    if (currentStep && currentStep === steps.length) {
+      complete?.();
     }
   }, [currentStep]);
   const goToPrevious = () => {

--- a/src/components/Wizard/useFormWizard.ts
+++ b/src/components/Wizard/useFormWizard.ts
@@ -32,7 +32,7 @@ export const useFormWizard = ({
   const goToStep = (step: number) => {
     setCurrentStep(step);
     const newStepHash = steps[step];
-    const stepIndex = history.findIndex(
+    const stepIndex = step === 0 ? 0 : history.findIndex(
       (historicStepHash) => historicStepHash === newStepHash
     );
     if (stepIndex === -1) {

--- a/src/createItemClass/BuilderMustBeHolder.tsx
+++ b/src/createItemClass/BuilderMustBeHolder.tsx
@@ -6,9 +6,9 @@ const BuilderMustBeHolder = ({ handleSubmit, data }: SubStepProps) => {
     handleSubmit({ builderMustBeHolder: value });
   return (
     <BooleanFormStep
-      title={`Should item classes based on ${
+      title={`Do you need to hold ${data?.mint} to build ${
         data?.name || "your item"
-      } be built with editions of ${data?.mint} only?`}
+      }?`}
       initialValue={data?.builderMustBeHolder}
       handleSubmit={submitHandler}
     />

--- a/src/createItemClass/BuilderMustBeHolder.tsx
+++ b/src/createItemClass/BuilderMustBeHolder.tsx
@@ -1,0 +1,21 @@
+import { SubStepProps } from "../components/Wizard/FormStep";
+import { BooleanFormStep } from "../components/Wizard/BooleanFormStep";
+
+const BuilderMustBeHolder = ({ handleSubmit, data }: SubStepProps) => {
+  const submitHandler = (value: string) =>
+    handleSubmit({ builderMustBeHolder: value });
+  return (
+    <BooleanFormStep
+      title={`Should item classes based on ${
+        data?.name || "your item"
+      } be built with editions of ${data?.mint} only?`}
+      initialValue={data?.builderMustBeHolder}
+      handleSubmit={submitHandler}
+    />
+  );
+};
+
+const title = "Who can build?";
+const hash = "builder-must-be-holder";
+
+export { BuilderMustBeHolder as Component, title, hash };

--- a/src/createItemClass/ChildrenMustBeEditions.tsx
+++ b/src/createItemClass/ChildrenMustBeEditions.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { SubStepProps } from "../components/Wizard/FormStep";
+import { BooleanFormStep } from "../components/Wizard/BooleanFormStep";
+
+const ChildrenMustBeEditions = ({ handleSubmit, data }: SubStepProps) => {
+  const submitHandler = (value: string) => handleSubmit({ childrenMustBeEditions: value });
+  return (
+    <BooleanFormStep
+      title={`Should item classes based on ${
+        data?.name || "your item"
+      } be built with editions of ${data?.mint} only?`}
+      initialValue={data?.childrenMustBeEditions}
+      handleSubmit={submitHandler}
+    />
+  );
+};
+
+const title = "Limit to editions";
+const hash = "children-must-be-editions";
+
+export { ChildrenMustBeEditions as Component, title, hash };

--- a/src/createItemClass/ConnectWallet.tsx
+++ b/src/createItemClass/ConnectWallet.tsx
@@ -5,12 +5,12 @@ import { useEffect } from "react";
 import { SubStepProps } from "../components/Wizard/FormStep"
 
 const ConnectWallet = ({handleSubmit}: SubStepProps) => {
-    const { publicKey } = useWallet();
+    const { publicKey, disconnecting } = useWallet();
     useEffect(() => {
-        if (publicKey) {
-            handleSubmit({connectedWallet: publicKey})
-        }
-    }, [publicKey])
+      if (publicKey && !disconnecting) {
+        handleSubmit({ connectedWallet: publicKey });
+      }
+    }, [publicKey, disconnecting]);
     return (
       <Block maxWidth="400px" alignSelf="center">
         <WalletMultiButton />

--- a/src/createItemClass/ConnectWallet.tsx
+++ b/src/createItemClass/ConnectWallet.tsx
@@ -1,0 +1,28 @@
+import { useWallet } from "@solana/wallet-adapter-react";
+import { WalletMultiButton } from "@solana/wallet-adapter-react-ui";
+import { Block } from "baseui/block";
+import { useEffect } from "react";
+import { SubStepProps } from "../components/Wizard/FormStep"
+
+const ConnectWallet = ({handleSubmit}: SubStepProps) => {
+    const { publicKey } = useWallet();
+    useEffect(() => {
+        if (publicKey) {
+            handleSubmit({connectedWallet: publicKey})
+        }
+    }, [publicKey])
+    return (
+      <Block maxWidth="400px" alignSelf="center">
+        <WalletMultiButton />
+      </Block>
+    );
+}
+
+const title = "Connect wallet"
+const hash = "connect-wallet"
+
+export {
+    ConnectWallet as Component,
+    title,
+    hash,
+}

--- a/src/createItemClass/Freebuild.tsx
+++ b/src/createItemClass/Freebuild.tsx
@@ -1,0 +1,45 @@
+import { SubStepProps } from "../components/Wizard/FormStep"
+import { RadioInput } from "../components/Wizard/Inputs";
+import { useState } from "react";
+import { FormBlock, SubmitButton } from "../components/Wizard/Form";
+import { getBooleanFromString, getStringFromBoolean } from "../components/Wizard/Inputs/Radio";
+
+const Freebuild = ({handleSubmit, data}: SubStepProps) => {
+    const [submitDisabled, setSubmitDisabled] = useState<boolean>(data?.freeBuild === undefined)
+    const handleSelect = (value: string) => {handleSubmit({freeBuild: getBooleanFromString(value)})};
+    const handleDeselect = () => setSubmitDisabled(true);
+    return (
+      <FormBlock>
+        <RadioInput.Standalone
+          title={`Is ${
+            data?.name || "your item"
+          } built by combining other items?`}
+          options={[
+            { title: "Yes", value: "true" },
+            { title: "No", value: "false" },
+          ]}
+          onSelect={handleSelect}
+          onDeselect={handleDeselect}
+          help="An item might require components or ingredients to build. For example, to build a flaming torch you'll need a stick, some cotton, and fire."
+          value={getStringFromBoolean(data?.freeBuild)}
+        />
+        <SubmitButton
+          type="button"
+          onClick={() => handleSubmit(data?.freeBuild)}
+          isLoading={false}
+          disabled={submitDisabled}
+        >
+          Next
+        </SubmitButton>
+      </FormBlock>
+    );
+}
+
+const title = "Has components?"
+const hash = "freebuild"
+
+export {
+    Freebuild as Component,
+    title,
+    hash,
+}

--- a/src/createItemClass/Freebuild.tsx
+++ b/src/createItemClass/Freebuild.tsx
@@ -1,39 +1,19 @@
 import { SubStepProps } from "../components/Wizard/FormStep"
-import { RadioInput } from "../components/Wizard/Inputs";
-import { useState } from "react";
-import { FormBlock, SubmitButton } from "../components/Wizard/Form";
-import { getBooleanFromString, getStringFromBoolean } from "../components/Wizard/Inputs/Radio";
+import { BooleanFormStep } from "../components/Wizard/BooleanFormStep";
 
 const Freebuild = ({handleSubmit, data}: SubStepProps) => {
-    const [submitDisabled, setSubmitDisabled] = useState<boolean>(data?.freeBuild === undefined)
-    const handleSelect = (value: string) => {handleSubmit({freeBuild: getBooleanFromString(value)})};
-    const handleDeselect = () => setSubmitDisabled(true);
-    return (
-      <FormBlock>
-        <RadioInput.Standalone
-          title={`Is ${
+  const submitHandler = (value: string) =>  handleSubmit({ freeBuild: value });
+  return (
+    <BooleanFormStep
+        title={`Is ${
             data?.name || "your item"
           } built by combining other items?`}
-          options={[
-            { title: "Yes", value: "true" },
-            { title: "No", value: "false" },
-          ]}
-          onSelect={handleSelect}
-          onDeselect={handleDeselect}
-          help="An item might require components or ingredients to build. For example, to build a flaming torch you'll need a stick, some cotton, and fire."
-          value={getStringFromBoolean(data?.freeBuild)}
-        />
-        <SubmitButton
-          type="button"
-          onClick={() => handleSubmit(data?.freeBuild)}
-          isLoading={false}
-          disabled={submitDisabled}
-        >
-          Next
-        </SubmitButton>
-      </FormBlock>
-    );
-}
+        help="An item might require components or ingredients to build. For example, to build a flaming torch you'll need a stick, some cotton, and fire."
+        initialValue={data?.freeBuild}
+        handleSubmit={submitHandler}
+      />
+  );
+};
 
 const title = "Has components?"
 const hash = "freebuild"

--- a/src/createItemClass/HasParent.tsx
+++ b/src/createItemClass/HasParent.tsx
@@ -1,0 +1,56 @@
+import { Formik, FormikHelpers } from "formik";
+import * as yup from "yup"
+import { SubStepProps } from "../components/Wizard/FormStep"
+import { Form, FormikSubmitButton } from "../components/Wizard/Form";
+import { RadioInput } from "../components/Wizard/Inputs";
+
+const HasParent = ({handleSubmit, data}: SubStepProps) => {
+    const schema = yup.object({
+        hasParent: yup.string().oneOf(["true", "false"]).required()
+    });
+    type TValues = yup.InferType<typeof schema>;
+    return (
+      <Formik
+        initialValues={{ hasParent: data?.data?.hasParent }}
+        onSubmit={(values: TValues, actions: FormikHelpers<TValues>) => {
+          actions.setSubmitting(true);
+          handleSubmit({hasParent: values?.hasParent === "true"});
+          actions.setSubmitting(false);
+        }}
+        validationSchema={schema}
+      >
+        {(props) => (
+          <Form onSubmit={props.handleSubmit}>
+            <RadioInput.Inline
+              name="hasParent"
+              title={`Should ${data?.name || "your item"} be defined...`}
+              options={[
+                {
+                  title: "By inherited from an existing item class",
+                  value: "true",
+                },
+                {
+                  title: "From scratch",
+                  value: "false",
+                },
+              ]}
+              onChange={props.handleChange}
+              onBlur={props.handleBlur}
+              value={props.values.hasParent}
+              error={props.errors.hasParent}
+            />
+            <FormikSubmitButton>Next</FormikSubmitButton>
+          </Form>
+        )}
+      </Formik>
+    );
+}
+
+const title = "Inherit?"
+const hash = "has-parent"
+
+export {
+    HasParent as Component,
+    title,
+    hash,
+}

--- a/src/createItemClass/HasParent.tsx
+++ b/src/createItemClass/HasParent.tsx
@@ -26,7 +26,7 @@ const HasParent = ({handleSubmit, data}: SubStepProps) => {
               title={`Should ${data?.name || "your item"} be defined...`}
               options={[
                 {
-                  title: "By inherited from an existing item class",
+                  title: "By inheriting from an existing item class",
                   value: "true",
                 },
                 {

--- a/src/createItemClass/HasParent.tsx
+++ b/src/createItemClass/HasParent.tsx
@@ -3,6 +3,7 @@ import * as yup from "yup"
 import { SubStepProps } from "../components/Wizard/FormStep"
 import { Form, FormikSubmitButton } from "../components/Wizard/Form";
 import { RadioInput } from "../components/Wizard/Inputs";
+import { getBooleanFromString, getStringFromBoolean } from "../components/Wizard/Inputs/Radio";
 
 const HasParent = ({handleSubmit, data}: SubStepProps) => {
     const schema = yup.object({
@@ -11,10 +12,10 @@ const HasParent = ({handleSubmit, data}: SubStepProps) => {
     type TValues = yup.InferType<typeof schema>;
     return (
       <Formik
-        initialValues={{ hasParent: data?.data?.hasParent }}
+        initialValues={{ hasParent: getStringFromBoolean(data?.hasParent) }}
         onSubmit={(values: TValues, actions: FormikHelpers<TValues>) => {
           actions.setSubmitting(true);
-          handleSubmit({hasParent: values?.hasParent === "true"});
+          handleSubmit({hasParent: getBooleanFromString(values?.hasParent)});
           actions.setSubmitting(false);
         }}
         validationSchema={schema}

--- a/src/createItemClass/HasUses.tsx
+++ b/src/createItemClass/HasUses.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { SubStepProps } from "../components/Wizard/FormStep"
+import { RadioInput } from "../components/Wizard/Inputs";
+import { useState } from "react";
+import { FormBlock, SubmitButton } from "../components/Wizard/Form";
+import { getBooleanFromString, getStringFromBoolean } from "../components/Wizard/Inputs/Radio";
+
+const HasUses = ({handleSubmit, data}: SubStepProps) => {
+    const [submitDisabled, setSubmitDisabled] = useState<boolean>(data?.hasUses === undefined)
+    const handleSelect = (value: string) => {handleSubmit({hasUses: getBooleanFromString(value)})};
+    const handleDeselect = () => setSubmitDisabled(true);
+    return (
+      <FormBlock>
+        <RadioInput.Standalone
+          title={`Does ${data?.name || "your item"} have any uses?`}
+          options={[
+            { title: "Yes", value: "true" },
+            { title: "No", value: "false" },
+          ]}
+          onSelect={handleSelect}
+          onDeselect={handleDeselect}
+          help="How do players interact with this item? Or is it instead a collectible?"
+          value={getStringFromBoolean(data?.hasUses)}
+        />
+        <SubmitButton
+          type="button"
+          onClick={() => handleSubmit(data?.hasUses)}
+          disabled={submitDisabled}
+        >
+          Next
+        </SubmitButton>
+      </FormBlock>
+    );
+}
+
+const title = "Has uses?"
+const hash = "has-uses"
+
+export {
+    HasUses as Component,
+    title,
+    hash,
+}

--- a/src/createItemClass/HasUses.tsx
+++ b/src/createItemClass/HasUses.tsx
@@ -1,36 +1,16 @@
-import * as React from "react";
 import { SubStepProps } from "../components/Wizard/FormStep"
-import { RadioInput } from "../components/Wizard/Inputs";
-import { useState } from "react";
-import { FormBlock, SubmitButton } from "../components/Wizard/Form";
-import { getBooleanFromString, getStringFromBoolean } from "../components/Wizard/Inputs/Radio";
+import { BooleanFormStep } from "../components/Wizard/BooleanFormStep";
 
 const HasUses = ({handleSubmit, data}: SubStepProps) => {
-    const [submitDisabled, setSubmitDisabled] = useState<boolean>(data?.hasUses === undefined)
-    const handleSelect = (value: string) => {handleSubmit({hasUses: getBooleanFromString(value)})};
-    const handleDeselect = () => setSubmitDisabled(true);
-    return (
-      <FormBlock>
-        <RadioInput.Standalone
-          title={`Does ${data?.name || "your item"} have any uses?`}
-          options={[
-            { title: "Yes", value: "true" },
-            { title: "No", value: "false" },
-          ]}
-          onSelect={handleSelect}
-          onDeselect={handleDeselect}
-          help="How do players interact with this item? Or is it instead a collectible?"
-          value={getStringFromBoolean(data?.hasUses)}
-        />
-        <SubmitButton
-          type="button"
-          onClick={() => handleSubmit(data?.hasUses)}
-          disabled={submitDisabled}
-        >
-          Next
-        </SubmitButton>
-      </FormBlock>
-    );
+  const submitHandler = (value: string) => handleSubmit({ hasUses: value });
+  return (
+    <BooleanFormStep
+      title={`Does ${data?.name || "your item"} have any uses?`}
+      help="How do players interact with this item? Or is it instead a collectible?"
+      initialValue={data?.hasUses}
+      handleSubmit={submitHandler}
+    />
+  );
 }
 
 const title = "Has uses?"

--- a/src/createItemClass/ItemClassIndex.tsx
+++ b/src/createItemClass/ItemClassIndex.tsx
@@ -1,0 +1,58 @@
+import { Formik, FormikHelpers } from "formik";
+import * as yup from "yup";
+import { SubStepProps } from "../components/Wizard/FormStep";
+import { Form, FormikSubmitButton } from "../components/Wizard/Form";
+import { IntegerInput } from "../components/Wizard/Inputs";
+import useNextItemClassIndex from "../hooks/useNextItemClassIndex";
+import { LoadingMessage } from "../components/LoadingMessage";
+import { LabelSmall } from "baseui/typography";
+
+const ItemClassIndex = ({ handleSubmit, data }: SubStepProps) => {
+  const { nextIndex, loading } = useNextItemClassIndex(data?.mint);
+  const schema = yup.object({
+    index: yup.number().min(0).required(),
+  });
+  type TValues = yup.InferType<typeof schema>;
+  return loading ? (
+    <LoadingItemClass mint={data?.mint} />
+  ) : (
+    <Formik
+      initialValues={{ index: data?.data?.index || nextIndex || 0 }}
+      onSubmit={(values: TValues, actions: FormikHelpers<TValues>) => {
+        actions.setSubmitting(true);
+        handleSubmit(values);
+        actions.setSubmitting(false);
+      }}
+      validationSchema={schema}
+    >
+      {(props) => (
+        <Form onSubmit={props.handleSubmit}>
+          <IntegerInput.Inline
+            name="index"
+            title="What index should we assign this item class too?"
+            help="Indexes allow you to re-use an NFT to define multiple item classes"
+            onChange={props.handleChange}
+            onBlur={props.handleBlur}
+            value={props.values.index}
+            error={props.errors.index}
+          />
+          <LabelSmall alignSelf="center">
+            First available index is: {nextIndex}
+          </LabelSmall>
+          <FormikSubmitButton>Next</FormikSubmitButton>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+const LoadingItemClass = ({ mint }: { mint: string }) => (
+  <LoadingMessage
+    message={`Checking if there are existing item classes for ${mint}`}
+  />
+);
+
+const title = "Select an index";
+const hash = "index";
+
+export { ItemClassIndex as Component, title, hash };

--- a/src/createItemClass/ItemClassIndex.tsx
+++ b/src/createItemClass/ItemClassIndex.tsx
@@ -18,7 +18,7 @@ const ItemClassIndex = ({ handleSubmit, data }: SubStepProps) => {
       if (value !== undefined) {
         const mintPublicKey = new PublicKey(data?.mint)
         const accountInfo = await getItemClassInfo(mintPublicKey, value, connection);
-        if (!accountInfo?.value) {
+        if (!accountInfo) {
           return true
         }
       }

--- a/src/createItemClass/ItemClassIndex.tsx
+++ b/src/createItemClass/ItemClassIndex.tsx
@@ -15,7 +15,7 @@ const ItemClassIndex = ({ handleSubmit, data }: SubStepProps) => {
   const { nextIndex, loading } = useNextItemClassIndex(data?.mint);
   const schema = yup.object({
     index: yup.number().min(0).required().test('indexInUse', 'This index is already in use.', async (value) => {
-      if (value) {
+      if (value !== undefined) {
         const mintPublicKey = new PublicKey(data?.mint)
         const accountInfo = await getItemClassInfo(mintPublicKey, value, connection);
         if (!accountInfo?.value) {
@@ -30,7 +30,7 @@ const ItemClassIndex = ({ handleSubmit, data }: SubStepProps) => {
     <LoadingItemClass mint={data?.mint} />
   ) : (
     <Formik
-      initialValues={{ index: data?.data?.index || nextIndex || 0 }}
+      initialValues={{ index: data?.index || nextIndex || 0 }}
       onSubmit={(values: TValues, actions: FormikHelpers<TValues>) => {
         actions.setSubmitting(true);
         handleSubmit(values);

--- a/src/createItemClass/MetadataUpdateAuthority.tsx
+++ b/src/createItemClass/MetadataUpdateAuthority.tsx
@@ -1,0 +1,48 @@
+import { useWallet } from "@solana/wallet-adapter-react";
+import { Formik, FormikHelpers } from "formik";
+import * as yup from "yup";
+import { FormikSubmitButton, Form } from "../components/Wizard/Form";
+import { SubStepProps } from "../components/Wizard/FormStep";
+import { PublicKeyInput } from "../components/Wizard/Inputs";
+
+const MetadataUpdateAuthority = ({ handleSubmit, data }: SubStepProps) => {
+  const {publicKey} = useWallet()
+  const schema = yup.object({
+    metadataUpdateAuthority: PublicKeyInput.validation.required(),
+  });
+  type TValues = yup.InferType<typeof schema>;
+  return (
+    <Formik
+      initialValues={{
+        metadataUpdateAuthority: data?.metadataUpdateAuthority || publicKey,
+      }}
+      validationSchema={schema}
+      onSubmit={(values: TValues, actions: FormikHelpers<TValues>) => {
+        actions.setSubmitting(true);
+        handleSubmit(values);
+        actions.setSubmitting(false);
+      }}
+    >
+      {(props) => (
+        <Form onSubmit={props.handleSubmit}>
+          <PublicKeyInput.Formik
+            name="metadataUpdateAuthority"
+            title="Who can update this item class?"
+            help="Enter the public key here"
+            onChange={props.handleChange}
+            onBlur={props.handleBlur}
+            value={props.values.metadataUpdateAuthority}
+            error={props.errors.metadataUpdateAuthority}
+          />
+          <FormikSubmitButton>Next</FormikSubmitButton>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+
+const title = "Update authority";
+const hash = "metadata-update-authority";
+
+export {MetadataUpdateAuthority as Component, title, hash}

--- a/src/createItemClass/NameItem.tsx
+++ b/src/createItemClass/NameItem.tsx
@@ -1,0 +1,47 @@
+import { Formik, FormikHelpers } from "formik";
+import * as yup from "yup"
+import { SubStepProps } from "../components/Wizard/FormStep"
+import { Form, FormikSubmitButton } from "../components/Wizard/Form";
+import { StringInput } from "../components/Wizard/Inputs";
+
+const NameItem = ({handleSubmit, data}: SubStepProps) => {
+    const schema = yup.object({
+        itemName: yup.string()
+    });
+    type TValues = yup.InferType<typeof schema>;
+    return (
+      <Formik
+        initialValues={{ itemName: data?.data?.itemName }}
+        onSubmit={(values: TValues, actions: FormikHelpers<TValues>) => {
+          actions.setSubmitting(true);
+          handleSubmit(values);
+          actions.setSubmitting(false);
+        }}
+        validationSchema={schema}
+      >
+        {(props) => (
+          <Form onSubmit={props.handleSubmit}>
+            <StringInput.Inline
+              name="itemName"
+              title="What is your item called?"
+              help="We'll use this to refer to the item throughout the flow"
+              onChange={props.handleChange}
+              onBlur={props.handleBlur}
+              value={props.values.itemName}
+              error={props.errors.itemName}
+            />
+            <FormikSubmitButton>Next</FormikSubmitButton>
+          </Form>
+        )}
+      </Formik>
+    );
+}
+
+const title = "Name your item"
+const hash = "name"
+
+export {
+    NameItem as Component,
+    title,
+    hash,
+}

--- a/src/createItemClass/ParentItemClass.tsx
+++ b/src/createItemClass/ParentItemClass.tsx
@@ -1,0 +1,47 @@
+import { Formik, FormikHelpers } from "formik";
+import * as yup from "yup"
+import { SubStepProps } from "../components/Wizard/FormStep"
+import { Form, FormikSubmitButton } from "../components/Wizard/Form";
+import { ItemClassKeyInput, PublicKeyInput } from "../components/Wizard/Inputs";
+
+const ParentItemClass = ({handleSubmit, data}: SubStepProps) => {
+    const schema = yup.object({
+        parent: PublicKeyInput.validation.required()
+    });
+    type TValues = yup.InferType<typeof schema>;
+    return (
+      <Formik
+        initialValues={{ parent: data?.data?.parent }}
+        onSubmit={(values: TValues, actions: FormikHelpers<TValues>) => {
+          actions.setSubmitting(true);
+          handleSubmit({ parent: values?.parent });
+          actions.setSubmitting(false);
+        }}
+        validationSchema={schema}
+      >
+        {(props) => (
+          <Form onSubmit={props.handleSubmit}>
+            <ItemClassKeyInput.Formik
+              name="parent"
+              title="Enter the item class key you want to inherit from"
+              help="Item classes based off a parent will inherit different properties, depending on what was defined in that parent."
+              onChange={props.handleChange}
+              onBlur={props.handleBlur}
+              value={props.values.parent}
+              error={props.errors.parent}
+            />
+            <FormikSubmitButton>Next</FormikSubmitButton>
+          </Form>
+        )}
+      </Formik>
+    );
+}
+
+const title = "Parent item class"
+const hash = "parent"
+
+export {
+    ParentItemClass as Component,
+    title,
+    hash,
+}

--- a/src/createItemClass/ParentItemClass.tsx
+++ b/src/createItemClass/ParentItemClass.tsx
@@ -11,7 +11,7 @@ const ParentItemClass = ({handleSubmit, data}: SubStepProps) => {
     type TValues = yup.InferType<typeof schema>;
     return (
       <Formik
-        initialValues={{ parent: data?.data?.parent }}
+        initialValues={{ parent: data?.parent }}
         onSubmit={(values: TValues, actions: FormikHelpers<TValues>) => {
           actions.setSubmitting(true);
           handleSubmit({ parent: values?.parent });

--- a/src/createItemClass/ParentItemClass.tsx
+++ b/src/createItemClass/ParentItemClass.tsx
@@ -7,14 +7,19 @@ import { ItemClassKeyInput, PublicKeyInput } from "../components/Wizard/Inputs";
 const ParentItemClass = ({ handleSubmit, data }: SubStepProps) => {
   const schema = yup.object({
     parent: PublicKeyInput.validation.required(),
+    parent_itemclass: yup.object({
+      mint: PublicKeyInput.validation.required(
+        "Selected item class does not have a mint stored"
+      )
+    })
   });
-  type TValues = yup.InferType<typeof schema>;
+  type TValues = Omit<yup.InferType<typeof schema>, 'parent_itemclass'> & {parent_itemclass?: any};
   return (
     <Formik
-      initialValues={{ parent: data?.parent }}
+      initialValues={{ parent: data?.parent, parent_itemclass: undefined }}
       onSubmit={(values: TValues, actions: FormikHelpers<TValues>) => {
         actions.setSubmitting(true);
-        handleSubmit({ parent: values?.parent });
+        handleSubmit({parent: values?.parent, parentItemClass: values?.parent_itemclass});
         actions.setSubmitting(false);
       }}
       validationSchema={schema}

--- a/src/createItemClass/ParentItemClass.tsx
+++ b/src/createItemClass/ParentItemClass.tsx
@@ -1,47 +1,43 @@
 import { Formik, FormikHelpers } from "formik";
-import * as yup from "yup"
-import { SubStepProps } from "../components/Wizard/FormStep"
+import * as yup from "yup";
+import { SubStepProps } from "../components/Wizard/FormStep";
 import { Form, FormikSubmitButton } from "../components/Wizard/Form";
 import { ItemClassKeyInput, PublicKeyInput } from "../components/Wizard/Inputs";
 
-const ParentItemClass = ({handleSubmit, data}: SubStepProps) => {
-    const schema = yup.object({
-        parent: PublicKeyInput.validation.required()
-    });
-    type TValues = yup.InferType<typeof schema>;
-    return (
-      <Formik
-        initialValues={{ parent: data?.parent }}
-        onSubmit={(values: TValues, actions: FormikHelpers<TValues>) => {
-          actions.setSubmitting(true);
-          handleSubmit({ parent: values?.parent });
-          actions.setSubmitting(false);
-        }}
-        validationSchema={schema}
-      >
-        {(props) => (
-          <Form onSubmit={props.handleSubmit}>
-            <ItemClassKeyInput.Formik
-              name="parent"
-              title="Enter the key of the item class you want to inherit from"
-              help="Item classes based off a parent will inherit different properties, depending on what was defined in that parent."
-              onChange={props.handleChange}
-              onBlur={props.handleBlur}
-              value={props.values.parent}
-              error={props.errors.parent}
-            />
-            <FormikSubmitButton>Next</FormikSubmitButton>
-          </Form>
-        )}
-      </Formik>
-    );
-}
+const ParentItemClass = ({ handleSubmit, data }: SubStepProps) => {
+  const schema = yup.object({
+    parent: PublicKeyInput.validation.required(),
+  });
+  type TValues = yup.InferType<typeof schema>;
+  return (
+    <Formik
+      initialValues={{ parent: data?.parent }}
+      onSubmit={(values: TValues, actions: FormikHelpers<TValues>) => {
+        actions.setSubmitting(true);
+        handleSubmit({ parent: values?.parent });
+        actions.setSubmitting(false);
+      }}
+      validationSchema={schema}
+    >
+      {(props) => (
+        <Form onSubmit={props.handleSubmit}>
+          <ItemClassKeyInput.Formik
+            name="parent"
+            title="Enter the key of the item class you want to inherit from"
+            help="Item classes based off a parent will inherit different properties, depending on what was defined in that parent."
+            onChange={props.handleChange}
+            onBlur={props.handleBlur}
+            value={props.values.parent}
+            error={props.errors.parent}
+          />
+          <FormikSubmitButton>Next</FormikSubmitButton>
+        </Form>
+      )}
+    </Formik>
+  );
+};
 
-const title = "Parent item class"
-const hash = "parent"
+const title = "Parent item class";
+const hash = "parent";
 
-export {
-    ParentItemClass as Component,
-    title,
-    hash,
-}
+export { ParentItemClass as Component, title, hash };

--- a/src/createItemClass/ParentItemClass.tsx
+++ b/src/createItemClass/ParentItemClass.tsx
@@ -23,7 +23,7 @@ const ParentItemClass = ({handleSubmit, data}: SubStepProps) => {
           <Form onSubmit={props.handleSubmit}>
             <ItemClassKeyInput.Formik
               name="parent"
-              title="Enter the item class key you want to inherit from"
+              title="Enter the key of the item class you want to inherit from"
               help="Item classes based off a parent will inherit different properties, depending on what was defined in that parent."
               onChange={props.handleChange}
               onBlur={props.handleBlur}

--- a/src/createItemClass/Review.tsx
+++ b/src/createItemClass/Review.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect } from "react";
+import { SubStepProps } from "../components/Wizard/FormStep";
+import { JSONInput } from "../components/Wizard/Inputs";
+import { FormBlock, SubmitButton } from "../components/Wizard/Form";
+import { LoadingMessage } from "../components/LoadingMessage";
+
+const ReviewData = ({
+  handleSubmit,
+  clean,
+  data,
+}: SubStepProps & { clean?: Function }) => {
+  const [loading, setLoading] = React.useState<boolean>(false);
+  const [cleanedData, setCleanedData] = React.useState<any>();
+  useEffect(() => {
+    if (clean) {
+      setLoading(true);
+      cleanData(clean, data, (output: any) => {
+        setCleanedData(output);
+        setLoading(false);
+      });
+    }
+  }, [data, clean]);
+  const submit = () => handleSubmit({ ...data, _cleaned: cleanedData || data });
+  return (
+    <FormBlock>
+      {!loading && (!clean || cleanedData) ? (
+        <JSONInput.Display
+          name="review"
+          title="Review your item class config"
+          value={cleanedData || data}
+          disabled
+        />
+      ) : (
+        <LoadingMessage message="Preparing data..." />
+      )}
+      <SubmitButton onClick={submit}>Complete</SubmitButton>
+    </FormBlock>
+  );
+};
+
+async function cleanData(
+  clean: Function,
+  data: object,
+  setCleanedData: Function
+) {
+  const cleanedData = await clean(data);
+  setCleanedData(cleanedData);
+}
+
+const title = "Review";
+const hash = "review";
+
+export { ReviewData as Component, title, hash };

--- a/src/createItemClass/Review.tsx
+++ b/src/createItemClass/Review.tsx
@@ -1,16 +1,22 @@
 import React, { useEffect } from "react";
+import { KIND as NOTIFICATION_KIND, Notification } from "baseui/notification";
+import { StyledLink } from "baseui/link";
 import { SubStepProps } from "../components/Wizard/FormStep";
 import { JSONInput } from "../components/Wizard/Inputs";
 import { FormBlock, SubmitButton } from "../components/Wizard/Form";
 import { LoadingMessage } from "../components/LoadingMessage";
+import useCreateItemClass from "../hooks/useCreateItemClass";
 
-const ReviewData = ({
-  handleSubmit,
-  clean,
-  data,
-}: SubStepProps & { clean?: Function }) => {
+const ReviewData = ({ clean, data }: SubStepProps & { clean?: Function }) => {
   const [loading, setLoading] = React.useState<boolean>(false);
   const [cleanedData, setCleanedData] = React.useState<any>();
+  const {
+    createItemClass,
+    success,
+    error,
+    transactionUrl,
+    loading: creatingItemClass,
+  } = useCreateItemClass();
   useEffect(() => {
     if (clean) {
       setLoading(true);
@@ -20,7 +26,9 @@ const ReviewData = ({
       });
     }
   }, [data, clean]);
-  const submit = () => handleSubmit({ ...data, _cleaned: cleanedData || data });
+  const submit = () => {
+    createItemClass({ config: cleanedData || data });
+  };
   return (
     <FormBlock>
       {!loading && (!clean || cleanedData) ? (
@@ -33,7 +41,24 @@ const ReviewData = ({
       ) : (
         <LoadingMessage message="Preparing data..." />
       )}
-      <SubmitButton onClick={submit}>Complete</SubmitButton>
+      {success && (
+        <Notification kind={NOTIFICATION_KIND.positive}>
+          <>
+            Item class transaction:{" "}
+            <StyledLink href={transactionUrl} target="_blank">
+              View on explorer
+            </StyledLink>
+          </>
+        </Notification>
+      )}
+      {error && (
+        <Notification kind={NOTIFICATION_KIND.negative}>
+          <>Item class could not be created: {error.message}</>
+        </Notification>
+      )}
+      <SubmitButton onClick={submit} disabled={creatingItemClass || !!error}>
+        Complete
+      </SubmitButton>
     </FormBlock>
   );
 };

--- a/src/createItemClass/TokenSelect.tsx
+++ b/src/createItemClass/TokenSelect.tsx
@@ -1,0 +1,54 @@
+import { Formik, FormikHelpers } from "formik";
+import * as yup from "yup";
+import { SubStepProps } from "../components/Wizard/FormStep";
+import { Form, FormikSubmitButton } from "../components/Wizard/Form";
+import { TokenInput } from "../components/Wizard/Inputs";
+import { TokenInputProps } from "../components/Wizard/Inputs/Token";
+
+const TokenSelect = ({
+  handleSubmit,
+  data,
+  name,
+  inputTitle,
+  help,
+}: SubStepProps & {
+  name: TokenInputProps["name"];
+  inputTitle?: TokenInputProps["title"];
+  help?: TokenInputProps["help"];
+}) => {
+  const schema = yup.object({
+    [name]: yup.string().required(),
+  });
+  type TValues = yup.InferType<typeof schema>;
+  return (
+    <Formik
+      initialValues={{ [name]: data?.[name] }}
+      onSubmit={(values: TValues, actions: FormikHelpers<TValues>) => {
+        actions.setSubmitting(true);
+        handleSubmit(values);
+        actions.setSubmitting(false);
+      }}
+      validationSchema={schema}
+    >
+      {(props) => (
+        <Form onSubmit={props.handleSubmit}>
+          <TokenInput.Formik
+            name={name}
+            title={
+              inputTitle || `Select an NFT to base ${data?.name || "your item"} on`
+            }
+            help={help || "This forms the basis of the item that will be built"}
+            value={props.values?.[name]}
+            error={props.errors?.[name]}
+          />
+          <FormikSubmitButton>Next</FormikSubmitButton>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+const title = "Select NFT";
+const hash = "select-nft-mint";
+
+export { TokenSelect as Component, title, hash };

--- a/src/createItemClass/index.tsx
+++ b/src/createItemClass/index.tsx
@@ -13,13 +13,15 @@ import * as HasUses from "./HasUses";
 import * as Review from "./Review";
 import * as BuilderMustBeHolder from "./BuilderMustBeHolder";
 import useNetwork from "../hooks/useNetwork";
+import {
+  CreateItemClassArgs,
+} from "../hooks/useCreateItemClass";
 
 const CreateItemClassWizard = () => {
   const { network } = useNetwork();
   const [restart, setRestart] = useState<Date>();
   const { disconnect } = useWallet();
   const [data, setData] = useState<any>({});
-  const printData = () => console.log({ data });
   const disconnectAndRestart = async () => {
     await disconnect();
     setData({});
@@ -30,7 +32,6 @@ const CreateItemClassWizard = () => {
   }, [network]);
   return (
     <Wizard
-      onComplete={printData}
       values={data}
       setValues={setData}
       restartOnChange={restart}
@@ -99,42 +100,70 @@ const CreateItemClassWizard = () => {
   );
 };
 
-function prepareItemClassConfig(data: any) {
-  const {metadataUpdateAuthority, mint, itemClassIndex, freeBuild} = data
+function prepareItemClassConfig(data: ItemClassFormData): CreateItemClassArgs['config'] {
+  const { metadataUpdateAuthority, mint, index, freeBuild } = data;
   return {
     data: {
       settings: {
         freeBuild: {
           boolean: freeBuild,
-          inherited: null,
+          // @ts-ignore
+          inherited: { notInherited: true }, // State.InheritanceState.NotInherited,
         },
+        childrenMustBeEditions: null,
+        builderMustBeHolder: null,
+        updatePermissiveness: null,
+        buildPermissiveness: [
+          {
+            // @ts-ignore
+            permissivenessType: {
+              tokenHolder: true,
+            },
+            // @ts-ignore
+            inherited: {
+              notInherited: true,
+            },
+          },
+        ],
+        stakingWarmUpDuration: null,
+        stakingCooldownDuration: null,
+        stakingPermissiveness: null,
+        unstakingPermissiveness: null,
+        childUpdatePropagationPermissiveness: [],
       },
-      childrenMustBeEditions: false,
-      builderMustBeHolder: false,
-      updatePermissiveness: null,
-      buildPermissiveness: [],
-      stakingWarmUpDuration: null,
-      stakingCooldownDuration: null,
-      stakingPermissiveness: null,
-      unstakingPermissiveness: null,
-      childUpdatePropagationPermissiveness: [],
+      config: {
+        usageRoot: null,
+        usageStateRoot: null,
+        componentRoot: null,
+        usages: [],
+        components: [],
+      },
     },
-    config: {
-      usageRoot: null,
-      usageStateRoot: null,
-      componentRoot: null,
-      usages: [],
-      components: [],
-    },
-    metadataUpdateAuthority,
+    metadataUpdateAuthority: metadataUpdateAuthority || null,
     storeMint: false,
     storeMetadataFields: false,
     mint,
-    index: itemClassIndex,
-    updatePermissivenessToUse: null,
+    index,
+    updatePermissivenessToUse: {
+      tokenHolder: true,
+    },
     namespaceRequirement: 1,
     totalSpaceBytes: 300,
   };
 }
+
+type ItemClassFormData = {
+  connectedWallet: string;
+  name?: string;
+  mint: string;
+  index: number;
+  hasParent: boolean;
+  parentItemClassKey?: string;
+  freeBuild: boolean;
+  hasComponents: boolean;
+  hasUses: boolean;
+  metadataUpdateAuthority?: string;
+  builderMustBeHolder: boolean;
+};
 
 export { CreateItemClassWizard };

--- a/src/createItemClass/index.tsx
+++ b/src/createItemClass/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useWallet } from "@solana/wallet-adapter-react";
 import { Wizard } from "../components/Wizard";
 import * as ConnectWallet from "./ConnectWallet";
 import * as NameItem from "./NameItem";
@@ -8,8 +9,9 @@ import * as HasParent from "./HasParent";
 import * as ParentItemClass from "./ParentItemClass";
 import * as MetadataUpdateAuthority from "./MetadataUpdateAuthority";
 import * as Freebuild from "./Freebuild";
+import * as HasUses from "./HasUses";
+import * as Review from "./Review";
 import useNetwork from "../hooks/useNetwork";
-import { useWallet } from "@solana/wallet-adapter-react";
 
 const CreateItemClassWizard = () => {
   const { network } = useNetwork();
@@ -76,8 +78,57 @@ const CreateItemClassWizard = () => {
         hash={Freebuild.hash}
         Component={Freebuild.Component}
       />
+      <Wizard.Step
+        title={HasUses.title}
+        hash={HasUses.hash}
+        Component={HasUses.Component}
+      />
+      <Wizard.Step
+        title={Review.title}
+        hash={Review.hash}
+        Component={Review.Component}
+        clean={prepareItemClassConfig}
+      />
     </Wizard>
   );
 };
+
+function prepareItemClassConfig(data: any) {
+  const {metadataUpdateAuthority, mint, itemClassIndex, freeBuild} = data
+  return {
+    data: {
+      settings: {
+        freeBuild: {
+          boolean: freeBuild,
+          inherited: null,
+        },
+      },
+      childrenMustBeEditions: false,
+      builderMustBeHolder: false,
+      updatePermissiveness: null,
+      buildPermissiveness: [],
+      stakingWarmUpDuration: null,
+      stakingCooldownDuration: null,
+      stakingPermissiveness: null,
+      unstakingPermissiveness: null,
+      childUpdatePropagationPermissiveness: [],
+    },
+    config: {
+      usageRoot: null,
+      usageStateRoot: null,
+      componentRoot: null,
+      usages: [],
+      components: [],
+    },
+    metadataUpdateAuthority,
+    storeMint: false,
+    storeMetadataFields: false,
+    mint,
+    index: itemClassIndex,
+    updatePermissivenessToUse: null,
+    namespaceRequirement: 1,
+    totalSpaceBytes: 300,
+  };
+}
 
 export { CreateItemClassWizard };

--- a/src/createItemClass/index.tsx
+++ b/src/createItemClass/index.tsx
@@ -11,6 +11,7 @@ import * as MetadataUpdateAuthority from "./MetadataUpdateAuthority";
 import * as Freebuild from "./Freebuild";
 import * as HasUses from "./HasUses";
 import * as Review from "./Review";
+import * as BuilderMustBeHolder from "./BuilderMustBeHolder";
 import useNetwork from "../hooks/useNetwork";
 
 const CreateItemClassWizard = () => {
@@ -82,6 +83,11 @@ const CreateItemClassWizard = () => {
         title={HasUses.title}
         hash={HasUses.hash}
         Component={HasUses.Component}
+      />
+      <Wizard.Step
+        title={BuilderMustBeHolder.title}
+        hash={BuilderMustBeHolder.hash}
+        Component={BuilderMustBeHolder.Component}
       />
       <Wizard.Step
         title={Review.title}

--- a/src/createItemClass/index.tsx
+++ b/src/createItemClass/index.tsx
@@ -7,6 +7,7 @@ import * as ItemClassIndex from "./ItemClassIndex";
 import * as HasParent from "./HasParent";
 import * as ParentItemClass from "./ParentItemClass";
 import * as MetadataUpdateAuthority from "./MetadataUpdateAuthority";
+import * as Freebuild from "./Freebuild";
 
 const CreateItemClassWizard = () => {
   const [data, setData] = useState<any>({});
@@ -52,6 +53,11 @@ const CreateItemClassWizard = () => {
           Component={MetadataUpdateAuthority.Component}
         />
       )}
+      <Wizard.Step
+        title={Freebuild.title}
+        hash={Freebuild.hash}
+        Component={Freebuild.Component}
+      />
     </Wizard>
   );
 };

--- a/src/createItemClass/index.tsx
+++ b/src/createItemClass/index.tsx
@@ -6,6 +6,7 @@ import * as TokenSelect from "./TokenSelect";
 import * as ItemClassIndex from "./ItemClassIndex";
 import * as HasParent from "./HasParent";
 import * as ParentItemClass from "./ParentItemClass";
+import * as MetadataUpdateAuthority from "./MetadataUpdateAuthority";
 
 const CreateItemClassWizard = () => {
   const [data, setData] = useState<any>({});
@@ -38,11 +39,19 @@ const CreateItemClassWizard = () => {
         hash={HasParent.hash}
         Component={HasParent.Component}
       />
-      {data?.hasParent && <Wizard.Step
-        title={ParentItemClass.title}
-        hash={ParentItemClass.hash}
-        Component={ParentItemClass.Component}
-      />}
+      {data?.hasParent ? (
+        <Wizard.Step
+          title={ParentItemClass.title}
+          hash={ParentItemClass.hash}
+          Component={ParentItemClass.Component}
+        />
+      ) : (
+        <Wizard.Step
+          title={MetadataUpdateAuthority.title}
+          hash={MetadataUpdateAuthority.hash}
+          Component={MetadataUpdateAuthority.Component}
+        />
+      )}
     </Wizard>
   );
 };

--- a/src/createItemClass/index.tsx
+++ b/src/createItemClass/index.tsx
@@ -16,6 +16,7 @@ import * as BuilderMustBeHolder from "./BuilderMustBeHolder";
 import * as ChildrenMustBeEditions from "./ChildrenMustBeEditions";
 import useNetwork from "../hooks/useNetwork";
 import { CreateItemClassArgs } from "../hooks/useCreateItemClass";
+import { State } from "@raindrops-protocol/raindrops";
 
 const CreateItemClassWizard = () => {
   const { network } = useNetwork();
@@ -113,6 +114,7 @@ function prepareItemClassConfig(
     freeBuild,
     builderMustBeHolder,
     childrenMustBeEditions = null,
+    parent_itemclass: parentItemClass,
   } = data;
   return {
     data: {
@@ -163,10 +165,11 @@ function prepareItemClassConfig(
       },
     },
     metadataUpdateAuthority: metadataUpdateAuthority || null,
-    storeMint: false,
-    storeMetadataFields: false,
+    storeMint: true,
+    storeMetadataFields: true,
     mint,
     index,
+    parent: parentItemClass,
     updatePermissivenessToUse: {
       tokenHolder: true,
     },
@@ -187,7 +190,9 @@ type ItemClassFormData = {
   hasUses: boolean;
   metadataUpdateAuthority?: string;
   builderMustBeHolder: boolean;
-  childrenMustBeEditions: boolean;
+  childrenMustBeEditions?: boolean;
+  parent?: string;
+  parent_itemclass?: State.Item.ItemClass;
 };
 
 export { CreateItemClassWizard };

--- a/src/createItemClass/index.tsx
+++ b/src/createItemClass/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Wizard } from "../components/Wizard";
 import * as ConnectWallet from "./ConnectWallet";
 import * as NameItem from "./NameItem";
@@ -8,12 +8,30 @@ import * as HasParent from "./HasParent";
 import * as ParentItemClass from "./ParentItemClass";
 import * as MetadataUpdateAuthority from "./MetadataUpdateAuthority";
 import * as Freebuild from "./Freebuild";
+import useNetwork from "../hooks/useNetwork";
+import { useWallet } from "@solana/wallet-adapter-react";
 
 const CreateItemClassWizard = () => {
+  const { network } = useNetwork();
+  const [restart, setRestart] = useState<Date>();
+  const { disconnect } = useWallet();
   const [data, setData] = useState<any>({});
   const printData = () => console.log({ data });
+  const disconnectAndRestart = async () => {
+    await disconnect();
+    setData({});
+    setRestart(new Date());
+  };
+  useEffect(() => {
+    disconnectAndRestart();
+  }, [network]);
   return (
-    <Wizard onComplete={printData} values={data} setValues={setData}>
+    <Wizard
+      onComplete={printData}
+      values={data}
+      setValues={setData}
+      restartOnChange={restart}
+    >
       <Wizard.Step
         title={ConnectWallet.title}
         hash={ConnectWallet.hash}

--- a/src/createItemClass/index.tsx
+++ b/src/createItemClass/index.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { Wizard } from "../components/Wizard";
+import * as ConnectWallet from "./ConnectWallet";
+import * as NameItem from "./NameItem";
+import * as TokenSelect from "./TokenSelect";
+import * as ItemClassIndex from "./ItemClassIndex";
+import * as HasParent from "./HasParent";
+import * as ParentItemClass from "./ParentItemClass";
+
+const CreateItemClassWizard = () => {
+  const [data, setData] = useState<any>({});
+  const printData = () => console.log({ data });
+  return (
+    <Wizard onComplete={printData} values={data} setValues={setData}>
+      <Wizard.Step
+        title={ConnectWallet.title}
+        hash={ConnectWallet.hash}
+        Component={ConnectWallet.Component}
+      />
+      <Wizard.Step
+        title={NameItem.title}
+        hash={NameItem.hash}
+        Component={NameItem.Component}
+      />
+      <Wizard.Step
+        title={TokenSelect.title}
+        hash={TokenSelect.hash}
+        Component={TokenSelect.Component}
+        name="mint"
+      />
+      <Wizard.Step
+        title={ItemClassIndex.title}
+        hash={ItemClassIndex.hash}
+        Component={ItemClassIndex.Component}
+      />
+      <Wizard.Step
+        title={HasParent.title}
+        hash={HasParent.hash}
+        Component={HasParent.Component}
+      />
+      {data?.hasParent && <Wizard.Step
+        title={ParentItemClass.title}
+        hash={ParentItemClass.hash}
+        Component={ParentItemClass.Component}
+      />}
+    </Wizard>
+  );
+};
+
+export { CreateItemClassWizard };

--- a/src/hooks/useCreateItemClass.ts
+++ b/src/hooks/useCreateItemClass.ts
@@ -1,0 +1,158 @@
+import React from "react";
+
+import { BN } from "@project-serum/anchor";
+import { useWallet } from "@solana/wallet-adapter-react";
+import { Keypair, PublicKey } from "@solana/web3.js";
+import cloneDeep from "lodash.clonedeep";
+import { getItemProgram, State, Utils } from "@raindrops-protocol/raindrops";
+
+import useNetwork, { Networks } from "./useNetwork";
+import { getExplorerUrl, ExplorerUrl } from "./utils";
+
+export type ItemClassDefinition = {
+  data: State.Item.ItemClassData;
+  metadataUpdateAuthority: any | null;
+  storeMint: boolean;
+  storeMetadataFields: boolean;
+  mint: string;
+  index: number;
+  updatePermissivenessToUse: State.AnchorPermissivenessType | null;
+  namespaceRequirement: number;
+  totalSpaceBytes: number;
+  parent?: ItemClassDefinition;
+};
+
+export type CreateItemClassArgs = {
+  env: Networks;
+  config: ItemClassDefinition;
+  rpcUrl: string;
+  keypair: Keypair;
+};
+
+// Adapted from https://github.com/raindrops-protocol/raindrops/blob/0b52ea858ccdf3a95f2f085f0a9fc21060b33d18/js/src/cli/item.ts#L31
+const createItemClass = async ({
+  env,
+  config,
+  rpcUrl,
+  keypair,
+}: CreateItemClassArgs) => {
+  const anchorProgram = await getItemProgram(keypair, env, rpcUrl);
+  anchorProgram.asyncSigning = true;
+
+  if (config.data.config.components)
+    config.data.config.components = config.data.config.components.map((c) => ({
+      ...c,
+      mint: new PublicKey(c.mint),
+      classIndex: new BN(c.classIndex),
+      amount: new BN(c.amount),
+    }));
+
+  const {txid} = await anchorProgram.createItemClass(
+    {
+      classIndex: new BN(config.index || 0),
+      parentClassIndex: config.parent ? new BN(config.parent.index) : null,
+      space: new BN(config.totalSpaceBytes),
+      desiredNamespaceArraySize: config.namespaceRequirement,
+      updatePermissivenessToUse: config.updatePermissivenessToUse,
+      storeMint: config.storeMint,
+      storeMetadataFields: config.storeMetadataFields,
+      itemClassData: config.data as State.Item.ItemClassData,
+      parentOfParentClassIndex: config.parent?.parent
+        ? new BN(config.parent.parent.index)
+        : null,
+    },
+    {
+      itemMint: new PublicKey(config.mint),
+      parent: config.parent
+        ? (
+            await Utils.PDA.getItemPDA(
+              new PublicKey(config.parent.mint),
+              new BN(config.parent.index)
+            )
+          )[0]
+        : null,
+      parentMint: config.parent ? new PublicKey(config.parent.mint) : null,
+      parentOfParentClassMint: config.parent?.parent
+        ? new PublicKey(config.parent.parent.mint)
+        : null,
+      metadataUpdateAuthority: config.metadataUpdateAuthority
+        ? new PublicKey(config.metadataUpdateAuthority)
+        : keypair.publicKey,
+      parentUpdateAuthority: config.parent
+        ? config.parent.metadataUpdateAuthority
+        : null,
+    },
+    {}
+  );
+  return getExplorerUrl({ txId: txid, network: env });
+};
+
+const handleCreateItemClass = async ({
+  setLoading,
+  setSuccess,
+  setError,
+  setTransactionUrl,
+  env,
+  config,
+  rpcUrl,
+  keypair,
+}: CreateItemClassArgs & {
+  setLoading: Function;
+  setSuccess: Function;
+  setError: Function;
+  setTransactionUrl: Function;
+}) => {
+  try {
+    setLoading(true);
+    setSuccess(undefined);
+    setTransactionUrl(undefined);
+    setError(undefined);
+    const transactionUrl = await createItemClass({
+      env,
+      config: cloneDeep(config),
+      rpcUrl,
+      keypair,
+    });
+    setSuccess(true);
+    setTransactionUrl(transactionUrl);
+  } catch (e) {
+    setSuccess(false);
+    setError(e);
+  } finally {
+    setLoading(false);
+  }
+};
+
+const useCreateItemClass = () => {
+  const { network, endpoint } = useNetwork();
+  const wallet = useWallet();
+  const [loading, setLoading] = React.useState<boolean>(false);
+  const [success, setSuccess] = React.useState<boolean | undefined>();
+  const [transactionUrl, setTransactionUrl] =
+    React.useState<ExplorerUrl>();
+  const [error, setError] = React.useState<Error | undefined>();
+
+  const createItemClassHandler = ({
+    config,
+  }: Omit<CreateItemClassArgs, "env" | "rpcUrl" | "keypair">) =>
+    handleCreateItemClass({
+      setLoading,
+      setSuccess,
+      setError,
+      setTransactionUrl,
+      env: network,
+      config,
+      rpcUrl: endpoint,
+      keypair: wallet as unknown as Keypair,
+    }); // Urgh Typescript
+
+  return {
+    loading,
+    success,
+    error,
+    transactionUrl,
+    createItemClass: createItemClassHandler,
+  };
+};
+
+export default useCreateItemClass;

--- a/src/hooks/useFetchWalletTokens.ts
+++ b/src/hooks/useFetchWalletTokens.ts
@@ -43,7 +43,7 @@ const collateTokenInfoFromAccounts = (accounts: AccountResponse): TokenInfo[] =>
 
 export type TokenInfo = {
   mintAddr: string;
-  qty: number;
+  qty?: number;
 };
 
 const useFetchWalletTokens = () => {

--- a/src/hooks/useItemClass.ts
+++ b/src/hooks/useItemClass.ts
@@ -52,7 +52,6 @@ const useItemClass = (itemClassKey: string | undefined) => {
           );
           setLoadingState(Loading.Loaded);
         } catch (e) {
-          console.log(e);
           setLoadingState(Loading.Failed);
           setItemClass(undefined)
         }

--- a/src/hooks/useItemClass.ts
+++ b/src/hooks/useItemClass.ts
@@ -2,17 +2,8 @@ import { web3 } from "@project-serum/anchor";
 import { State } from "@raindrops-protocol/raindrops";
 import { useConnection } from "@solana/wallet-adapter-react";
 import { useEffect, useState } from "react";
-import { Connection, PublicKey } from "@solana/web3.js";
-import { Loading, withCallback } from "./utils";
-
-const getItemClass = async (
-  itemClassKey: web3.PublicKey,
-  connection: Connection,
-) => {
-  const accountInfo = await connection.getAccountInfo(itemClassKey);
-  if (!accountInfo?.data) return undefined
-  return State.Item.decodeItemClass(accountInfo?.data)
-};
+import { PublicKey } from "@solana/web3.js";
+import { Loading, withCallback, getItemClass } from "./utils";
 
 /**
  * Returns the item class for the given item class key if it exists, else undefined

--- a/src/hooks/useItemClass.ts
+++ b/src/hooks/useItemClass.ts
@@ -1,0 +1,66 @@
+import { web3 } from "@project-serum/anchor";
+import { State } from "@raindrops-protocol/raindrops";
+import { useConnection } from "@solana/wallet-adapter-react";
+import { useEffect, useState } from "react";
+import { Connection, PublicKey } from "@solana/web3.js";
+import { Loading, withCallback } from "./utils";
+
+const getItemClass = async (
+  itemClassKey: web3.PublicKey,
+  connection: Connection,
+) => {
+  const accountInfo = await connection.getAccountInfo(itemClassKey);
+  if (!accountInfo?.data) return undefined
+  return State.Item.decodeItemClass(accountInfo?.data)
+};
+
+/**
+ * Returns the item class for the given item class key if it exists, else undefined
+ * @param itemClassKey Passed as string - this is to avoid re-rendering nightmares with React
+ * @returns itemClass if found, else undefined
+ */
+const useItemClass = (itemClassKey: string | undefined) => {
+  const [itemClass, setItemClass] = useState<State.Item.ItemClass>();
+  const [currentItemClassKey, setCurrentItemClassKey] = useState<web3.PublicKey>();
+  const [loadingState, setLoadingState] = useState<Loading>();
+  const { connection } = useConnection();
+  useEffect(() => {
+    setItemClass(undefined);
+    setLoadingState(Loading.Unloaded);
+    try {
+      if (itemClassKey) {
+        const itemClassKeyPublicKey = itemClassKey
+          ? new PublicKey(itemClassKey)
+          : undefined;
+        setCurrentItemClassKey(itemClassKeyPublicKey);
+      } else {
+        setCurrentItemClassKey(undefined);
+      }
+    } catch (e) {
+        setCurrentItemClassKey(undefined);
+    }
+  }, [itemClassKey]);
+  useEffect(() => {
+    if (loadingState === Loading.Unloaded && currentItemClassKey) {
+      setLoadingState(Loading.Loading);
+      withCallback(async () => {
+        let fetchedItemClass: State.Item.ItemClass | undefined;
+        try {
+          fetchedItemClass = await getItemClass(
+            currentItemClassKey,
+            connection
+          );
+          setLoadingState(Loading.Loaded);
+        } catch (e) {
+          console.log(e);
+          setLoadingState(Loading.Failed);
+          setItemClass(undefined)
+        }
+        return fetchedItemClass;
+      }, setItemClass);
+    }
+  }, [connection, currentItemClassKey, loadingState]);
+  return {itemClass, loading: loadingState === Loading.Loading, failed: loadingState === Loading.Failed};
+};
+
+export default useItemClass;

--- a/src/hooks/useNextItemClassIndex.ts
+++ b/src/hooks/useNextItemClassIndex.ts
@@ -13,7 +13,7 @@ const getNextItemClassIndex = async (
   let index;
   for (let i of range(maxTries)) {
     const accountInfo = await getItemClassInfo(tokenMint, i, connection);
-    if (!accountInfo?.value) {
+    if (!accountInfo) {
       index = i;
       break;
     }

--- a/src/hooks/useNextItemClassIndex.ts
+++ b/src/hooks/useNextItemClassIndex.ts
@@ -13,7 +13,6 @@ const getNextItemClassIndex = async (
   let index;
   for (let i of range(maxTries)) {
     const accountInfo = await getItemClassInfo(tokenMint, i, connection);
-    console.log('owner', accountInfo.value?.owner.toString())
     if (!accountInfo?.value) {
       index = i;
       break;

--- a/src/hooks/useNextItemClassIndex.ts
+++ b/src/hooks/useNextItemClassIndex.ts
@@ -1,0 +1,71 @@
+import { web3 } from "@project-serum/anchor";
+import { useConnection } from "@solana/wallet-adapter-react";
+import { useEffect, useState } from "react";
+import { Connection, PublicKey } from "@solana/web3.js";
+import { range } from "lodash";
+import { getItemClassInfo, Loading, withCallback } from "./utils";
+
+const getNextItemClassIndex = async (
+  tokenMint: web3.PublicKey,
+  connection: Connection,
+  maxTries = 50
+) => {
+  let index;
+  for (let i of range(maxTries)) {
+    const accountInfo = await getItemClassInfo(tokenMint, i, connection);
+    console.log('owner', accountInfo.value?.owner.toString())
+    if (!accountInfo?.value) {
+      index = i;
+      break;
+    }
+  }
+  if (index === undefined) {
+    throw RangeError(
+      `Item classes were found for all indices up to ${maxTries}`
+    );
+  }
+  return index;
+};
+
+/**
+ * Finds the next available (unused) item class index for the given token mint
+ * @param tokenMint Passed as string - this is to avoid re-rendering nightmares with React
+ * @returns index as a number if found, else undefined
+ */
+const useNextItemClassIndex = (tokenMint: string | undefined) => {
+  const [nextIndex, setNextIndex] = useState<number>();
+  const [currentToken, setCurrentToken] = useState<web3.PublicKey>();
+  const [loadingState, setLoadingState] = useState<Loading>();
+  const { connection } = useConnection();
+  useEffect(() => {
+    setNextIndex(undefined);
+    setLoadingState(Loading.Unloaded);
+    if (tokenMint) {
+      const tokenMintPublicKey = tokenMint
+        ? new PublicKey(tokenMint)
+        : undefined;
+      setCurrentToken(tokenMintPublicKey);
+    } else {
+      setCurrentToken(undefined);
+    }
+  }, [tokenMint]);
+  useEffect(() => {
+    if (loadingState === Loading.Unloaded && currentToken) {
+      setLoadingState(Loading.Loading);
+      withCallback(async () => {
+        let index: number | undefined;
+        try {
+          index = await getNextItemClassIndex(currentToken, connection);
+          setLoadingState(Loading.Loaded);
+        } catch (e) {
+          console.log(e);
+          setLoadingState(Loading.Failed);
+        }
+        return index;
+      }, setNextIndex);
+    }
+  }, [connection, currentToken, loadingState]);
+  return {nextIndex, loading: loadingState !== Loading.Loaded};
+};
+
+export default useNextItemClassIndex;

--- a/src/hooks/useNextItemClassIndex.ts
+++ b/src/hooks/useNextItemClassIndex.ts
@@ -57,7 +57,6 @@ const useNextItemClassIndex = (tokenMint: string | undefined) => {
           index = await getNextItemClassIndex(currentToken, connection);
           setLoadingState(Loading.Loaded);
         } catch (e) {
-          console.log(e);
           setLoadingState(Loading.Failed);
         }
         return index;

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -1,6 +1,8 @@
 import { BN, web3 } from "@project-serum/anchor";
 import { Utils } from "@raindrops-protocol/raindrops";
 import { Connection } from "@solana/web3.js";
+import { Connection as ConnectionUtils } from "@raindrop-studios/sol-kit";
+import { getNetworkForWalletAdapter, Networks } from "./useNetwork";
 
 export const withCallback = async (asyncFunction: Function, callback: Function) => {
   const response = await asyncFunction();
@@ -22,4 +24,21 @@ export const getItemClassInfo = async (
   const [itemClassKey] = await Utils.PDA.getItemPDA(tokenMint, new BN(index));
   const accountInfo = await connection.getParsedAccountInfo(itemClassKey);
   return accountInfo;
+};
+
+export type ExplorerUrl = string | undefined
+
+export const getExplorerUrl = ({
+  txId,
+  network,
+}: {
+  txId: string;
+  network: Networks;
+}): ExplorerUrl => {
+  const networkFilter =
+    getNetworkForWalletAdapter(network) ||
+    `custom&customUrl=${ConnectionUtils.getClusterUrl(network)}`;
+  if (txId) {
+    return `https://explorer.solana.com/tx/${txId}?cluster=${networkFilter}`;
+  }
 };

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -1,5 +1,5 @@
 import { BN, web3 } from "@project-serum/anchor";
-import { Utils } from "@raindrops-protocol/raindrops";
+import { State, Utils } from "@raindrops-protocol/raindrops";
 import { Connection } from "@solana/web3.js";
 import { Connection as ConnectionUtils } from "@raindrop-studios/sol-kit";
 import { getNetworkForWalletAdapter, Networks } from "./useNetwork";
@@ -16,13 +16,22 @@ export enum Loading {
   Failed = 3,
 }
 
+export const getItemClass = async (
+  itemClassKey: web3.PublicKey,
+  connection: Connection
+) => {
+  const accountInfo = await connection.getAccountInfo(itemClassKey);
+  if (!accountInfo?.data) return undefined;
+  return State.Item.decodeItemClass(accountInfo?.data);
+};
+
 export const getItemClassInfo = async (
   tokenMint: web3.PublicKey,
   index: number,
   connection: Connection
 ) => {
   const [itemClassKey] = await Utils.PDA.getItemPDA(tokenMint, new BN(index));
-  const accountInfo = await connection.getParsedAccountInfo(itemClassKey);
+  const accountInfo = await getItemClass(itemClassKey, connection);
   return accountInfo;
 };
 

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -1,0 +1,25 @@
+import { BN, web3 } from "@project-serum/anchor";
+import { Utils } from "@raindrops-protocol/raindrops";
+import { Connection } from "@solana/web3.js";
+
+export const withCallback = async (asyncFunction: Function, callback: Function) => {
+  const response = await asyncFunction();
+  callback(response);
+};
+
+export enum Loading {
+  Unloaded = 0,
+  Loading = 1,
+  Loaded = 2,
+  Failed = 3,
+}
+
+export const getItemClassInfo = async (
+  tokenMint: web3.PublicKey,
+  index: number,
+  connection: Connection
+) => {
+  const [itemClassKey] = await Utils.PDA.getItemPDA(tokenMint, new BN(index));
+  const accountInfo = await connection.getParsedAccountInfo(itemClassKey);
+  return accountInfo;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,10 +2074,10 @@
     loglevel "^1.8.0"
     typescript "^4.3.5"
 
-"@raindrops-protocol/raindrops@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@raindrops-protocol/raindrops/-/raindrops-0.0.6.tgz#81906673f194c2772c73bb4acbfecd2606a531fd"
-  integrity sha512-JvlKLGZee88Pec/aHSCmO9kMOb3wa6mpDiOlTWrKvGZxa31Axp69htNaI48iO/Se8cvaD0sb1QE+ltfAFd9v7g==
+"@raindrops-protocol/raindrops@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@raindrops-protocol/raindrops/-/raindrops-0.0.7.tgz#ff59feeb3df52c6f973b2bdd5162356e931604da"
+  integrity sha512-HaZrGq+V13FPbddHuMDQFHqvTo2t0jMoI/gA9m8BfAFA8nSqACL+T92jMtrP7yK+ifasXyl61SDMoMAgZM5mwg==
   dependencies:
     "@project-serum/anchor" "^0.24.2"
     "@raindrop-studios/sol-kit" "^0.1.78"


### PR DESCRIPTION
- This covers the basic questions and sets defaults/blanks for the more complex flows (components, usages, permissiveness, inheritance)
- Includes some input/wizard updates, utility hooks, plus the steps themselves under `createItemClass` directory
- How do we get the parent's update authority? See here: https://github.com/raindrop-studios/creator-ui/pull/7/files#diff-5cc0c2dd391b26b5f928ad6819c071ffbbe447c87c716ae69625f063071106b8R86

Technically this PR relies on https://github.com/raindrops-protocol/raindrops/pull/36  due to ed647a3ba42936a1eec5a28ba4e898442fd9fb0c however as permissiveness isn't yet editable it won't break